### PR TITLE
Split up cohort analysis by SSO IdP

### DIFF
--- a/retention/cohort_analysis.py
+++ b/retention/cohort_analysis.py
@@ -418,7 +418,7 @@ def get_cohort_users_and_client_mapping(
 
 
 def get_cohort_clients_bucket(
-        cohort_users: Collection[str],
+        cohort_users: Collection[User],
         users_and_devices_to_client: Mapping[str, str],
         bucket_start_date: int,
         bucket_end_date: int,
@@ -447,15 +447,15 @@ def get_cohort_clients_bucket(
 
     # Get a map of the device ids that were active for each user during the usage bucket
     bucket_user_device_map = get_bucket_devices_by_user(
-        cohort_users, bucket_start_date, bucket_end_date
+        tuple(u.user_id for u in cohort_users), bucket_start_date, bucket_end_date
     )
 
     # build a list of users for each client, to deduplicate users
     clients_to_users = {}  # type: Dict[str, Set[str]]
     for user in cohort_users:
-        for device_id in bucket_user_device_map.get(user, []):
-            client = users_and_devices_to_client[user + "+" + device_id]
-            clients_to_users.setdefault(client, set()).add(user)
+        for device_id in bucket_user_device_map.get(user.user_id, []):
+            client = users_and_devices_to_client[user.user_id + "+" + device_id]
+            clients_to_users.setdefault(client, set()).add(user.user_id)
 
     # then convert to a count of users per client.
     #
@@ -496,7 +496,7 @@ def generate_by_cohort(cohort_start_date, buckets, period):
         bucket_end_date = bucket_start_date + period
 
         client_types = get_cohort_clients_bucket(
-            tuple(u.user_id for u in cohort_users),
+            cohort_users,
             users_and_devices_to_client,
             bucket_start_date,
             bucket_end_date,
@@ -540,7 +540,7 @@ def generate_by_bucket(
 
         bucket_num = bucket + 1
         client_types = get_cohort_clients_bucket(
-            tuple(u.user_id for u in cohort_users),
+            cohort_users,
             users_and_devices_to_client,
             bucket_start_date,
             bucket_end_date,

--- a/retention/requirements.txt
+++ b/retention/requirements.txt
@@ -1,2 +1,3 @@
 mysqlclient==2.0.3
 psycopg2-binary==2.7.6.1
+attrs==20.3.0

--- a/retention/schema.sql
+++ b/retention/schema.sql
@@ -50,4 +50,24 @@ CREATE TABLE `cohorts_monthly` (
   `b11` int(11) NOT NULL DEFAULT '0',
   `b12` int(11) NOT NULL DEFAULT '0',
   UNIQUE KEY `client_date` (`client`,`date`)
-) ENGINE=InnoDB
+) ENGINE=InnoDB;
+
+
+-- add an `sso_idp` column to each of the cohort tables, so that we can break down
+-- retention by IDP. In order function correctly as part of a unique key, it needs to
+-- be non-nullable, since mysql treats (null = null) as false.
+
+ALTER TABLE `cohorts_daily`
+   ADD COLUMN `sso_idp` varchar(16) NOT NULL DEFAULT '',
+   ADD UNIQUE KEY `client_idp_date` (`client`,`sso_idp`, `date`),
+   DROP KEY `client_date`;
+
+ALTER TABLE `cohorts_weekly`
+   ADD COLUMN `sso_idp` varchar(16) NOT NULL DEFAULT '',
+   ADD UNIQUE KEY `client_idp_date` (`client`,`sso_idp`, `date`),
+   DROP KEY `client_date`;
+
+ALTER TABLE `cohorts_monthly`
+   ADD COLUMN `sso_idp` varchar(16) NOT NULL DEFAULT '',
+   ADD UNIQUE KEY `client_idp_date` (`client`,`sso_idp`, `date`),
+   DROP KEY `client_date`;


### PR DESCRIPTION
The intention here is to provide insights into whether SSO improves absolute user numbers or retention. To do so we break down the existing user numbers by SSO Identity Provider.

I've attempted to structure this PR in a way that has a series of independently-reviewable commits. All but the last one are non-functional (tested by running it against the live postgres and a local MySQL, and checking I got the same numbers in both cohort mode and bucket mode).

There is of necessity a change to the schema. I've updated the schema.sql file to include the necessary `ALTER TABLE`s, and it is my intention to run these manually before deploying the updated script.