### PR TITLE
Add GitHub Actions-based CI to run unit tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,27 @@
+name: Tests
+
+on:
+  push:
+    branches: ["develop", "release-*"]
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_PASSWORD: verysecret
+        ports:
+          - 5432:5432
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.x"
+      - run: |
+          pip install -r retention/requirements.txt
+          SYNAPSE_DB_HOST=postgres SYNAPSE_DB_USERNAME=postgres SYNAPSE_DB_PASSWORD=verysecret SYNAPSE_DB_DATABASE=postgres SYNAPSE_DB_OPTIONS= STATS_DB_HOST= STATS_DB_USERNAME= STATS_DB_PASSWORD= STATS_DB_DATABASE= python3 -m unittest retention.test.test_cohort_analysis

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,9 +19,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+
       - uses: actions/setup-python@v2
         with:
           python-version: "3.x"
-      - run: |
-          pip install -r retention/requirements.txt
-          SYNAPSE_DB_HOST=localhost SYNAPSE_DB_PORT=5432 SYNAPSE_DB_USERNAME=postgres SYNAPSE_DB_PASSWORD=verysecret SYNAPSE_DB_DATABASE=postgres SYNAPSE_DB_OPTIONS= STATS_DB_HOST= STATS_DB_USERNAME= STATS_DB_PASSWORD= STATS_DB_DATABASE= python3 -m unittest retention.test.test_cohort_analysis
+
+      - name: Install requirements
+        run: pip install -r retention/requirements.txt
+
+      - name: Run the unit tests
+        run: SYNAPSE_DB_HOST=localhost SYNAPSE_DB_PORT=5432 SYNAPSE_DB_USERNAME=postgres SYNAPSE_DB_PASSWORD=verysecret SYNAPSE_DB_DATABASE=postgres SYNAPSE_DB_OPTIONS= STATS_DB_HOST= STATS_DB_USERNAME= STATS_DB_PASSWORD= STATS_DB_DATABASE= python3 -m unittest retention.test.test_cohort_analysis

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,6 +23,6 @@ jobs:
         with:
           python-version: "3.x"
       - run: |
-          sudo apt install python3-dev
+          sudo apt install python3-dev libpq-dev
           pip install -r retention/requirements.txt
           SYNAPSE_DB_HOST=postgres SYNAPSE_DB_USERNAME=postgres SYNAPSE_DB_PASSWORD=verysecret SYNAPSE_DB_DATABASE=postgres SYNAPSE_DB_OPTIONS= STATS_DB_HOST= STATS_DB_USERNAME= STATS_DB_PASSWORD= STATS_DB_DATABASE= python3 -m unittest retention.test.test_cohort_analysis

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,4 +24,4 @@ jobs:
           python-version: "3.x"
       - run: |
           pip install -r retention/requirements.txt
-          SYNAPSE_DB_HOST=postgres SYNAPSE_DB_USERNAME=postgres SYNAPSE_DB_PASSWORD=verysecret SYNAPSE_DB_DATABASE=postgres SYNAPSE_DB_OPTIONS= STATS_DB_HOST= STATS_DB_USERNAME= STATS_DB_PASSWORD= STATS_DB_DATABASE= python3 -m unittest retention.test.test_cohort_analysis
+          SYNAPSE_DB_HOST=localhost SYNAPSE_DB_PORT=5432 SYNAPSE_DB_USERNAME=postgres SYNAPSE_DB_PASSWORD=verysecret SYNAPSE_DB_DATABASE=postgres SYNAPSE_DB_OPTIONS= STATS_DB_HOST= STATS_DB_USERNAME= STATS_DB_PASSWORD= STATS_DB_DATABASE= python3 -m unittest retention.test.test_cohort_analysis

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,4 +28,4 @@ jobs:
         run: pip install -r retention/requirements.txt
 
       - name: Run the unit tests
-        run: SYNAPSE_DB_HOST=localhost SYNAPSE_DB_PORT=5432 SYNAPSE_DB_USERNAME=postgres SYNAPSE_DB_PASSWORD=verysecret SYNAPSE_DB_DATABASE=postgres SYNAPSE_DB_OPTIONS= STATS_DB_HOST= STATS_DB_USERNAME= STATS_DB_PASSWORD= STATS_DB_DATABASE= python3 -m unittest retention.test.test_cohort_analysis
+        run: SYNAPSE_DB_HOST=localhost SYNAPSE_DB_PORT=5432 SYNAPSE_DB_USERNAME=postgres SYNAPSE_DB_PASSWORD=verysecret SYNAPSE_DB_DATABASE=postgres SYNAPSE_DB_OPTIONS= STATS_DB_HOST= STATS_DB_USERNAME= STATS_DB_PASSWORD= STATS_DB_DATABASE= python3 -m unittest retention.test.test_cohort_analysis -v

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,6 +23,6 @@ jobs:
         with:
           python-version: "3.x"
       - run: |
-          apt install python3-dev
+          sudo apt install python3-dev
           pip install -r retention/requirements.txt
           SYNAPSE_DB_HOST=postgres SYNAPSE_DB_USERNAME=postgres SYNAPSE_DB_PASSWORD=verysecret SYNAPSE_DB_DATABASE=postgres SYNAPSE_DB_OPTIONS= STATS_DB_HOST= STATS_DB_USERNAME= STATS_DB_PASSWORD= STATS_DB_DATABASE= python3 -m unittest retention.test.test_cohort_analysis

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,5 +23,6 @@ jobs:
         with:
           python-version: "3.x"
       - run: |
+          apt install python3-dev
           pip install -r retention/requirements.txt
           SYNAPSE_DB_HOST=postgres SYNAPSE_DB_USERNAME=postgres SYNAPSE_DB_PASSWORD=verysecret SYNAPSE_DB_DATABASE=postgres SYNAPSE_DB_OPTIONS= STATS_DB_HOST= STATS_DB_USERNAME= STATS_DB_PASSWORD= STATS_DB_DATABASE= python3 -m unittest retention.test.test_cohort_analysis

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,6 +23,5 @@ jobs:
         with:
           python-version: "3.x"
       - run: |
-          sudo apt install python3-dev libpq-dev
           pip install -r retention/requirements.txt
           SYNAPSE_DB_HOST=postgres SYNAPSE_DB_USERNAME=postgres SYNAPSE_DB_PASSWORD=verysecret SYNAPSE_DB_DATABASE=postgres SYNAPSE_DB_OPTIONS= STATS_DB_HOST= STATS_DB_USERNAME= STATS_DB_PASSWORD= STATS_DB_DATABASE= python3 -m unittest retention.test.test_cohort_analysis

--- a/README.md
+++ b/README.md
@@ -31,3 +31,7 @@ To then run the cohort analysis script:
 docker build -t cohort_analysis .
 docker run -it --env-file .env --network synapse --network-alias cohort-analysis --rm cohort_analysis <ARGS>
 ```
+
+## Unit tests
+
+**DO NOT** run the unit tests against a real Synapse database. The unit tests will create their own tables, deleting existing ones first if necessary.

--- a/retention/README.md
+++ b/retention/README.md
@@ -14,7 +14,7 @@ Install dependencies
 
 Create the local postgres instance.
 
-`$ docker run --name postgresql-container -p 5432:5432 -e POSTGRES_USER=test -e POSTGRES_PASSWORD=somePassword -d postgres`
+`docker run --name postgresql-container -p 5432:5432 -e POSTGRES_USER=test -e POSTGRES_PASSWORD=somePassword -d postgres`
 
 From the root directory, run tests with the appropriate environment variables.
 

--- a/retention/requirements.txt
+++ b/retention/requirements.txt
@@ -1,3 +1,3 @@
 mysqlclient==2.0.3
-psycopg2-binary==2.7.6.1
+psycopg2-binary==2.9.1
 attrs==20.3.0


### PR DESCRIPTION
This also increases the version of `psycopg2` because the old one fails to compile with recent Python versions.