### PR TITLE
Client-agnostic retention stats (cohort retention combined across all clients)

### DIFF
--- a/retention/cohort_analysis.py
+++ b/retention/cohort_analysis.py
@@ -57,7 +57,7 @@ class Config:
 
 def str_to_ts(datestring):
     return int(
-        1000 * time.mktime(datetime.datetime.strptime(datestring, "%Y-%m-%d").timetuple())
+        1000 * datetime.datetime.strptime(datestring, "%Y-%m-%d").replace(tzinfo=datetime.timezone.utc).timestamp()
     )
 
 
@@ -69,7 +69,7 @@ def ts_to_str(ts):
         (str): date in format %Y-%m-%d
     """
 
-    return(datetime.datetime.fromtimestamp(ts / 1000).strftime("%Y-%m-%d"))
+    return datetime.datetime.fromtimestamp(ts / 1000, tz=datetime.timezone.utc).strftime("%Y-%m-%d")
 
 
 def get_args():
@@ -103,7 +103,7 @@ def get_args():
     group = ap.add_mutually_exclusive_group(required=True)
     group.add_argument(
         "--cohort_start_date",
-        type=lambda d: datetime.datetime.strptime(d, "%Y-%m-%d"),
+        type=str_to_ts,
         help="""
             Enable cohort mode. In this mode, a single cohort of PERIOD days is tracked
             through BUCKETS activity buckets, each of PERIOD days. Option gives the
@@ -113,7 +113,7 @@ def get_args():
 
     group.add_argument(
         "--bucket_start_date",
-        type=lambda d: datetime.datetime.strptime(d, "%Y-%m-%d"),
+        type=str_to_ts,
         help="""
             Enable bucket mode. In this mode, a single activity bucket of PERIOD days
             is analyzed for activity from each of BUCKETS cohorts of PERIOD days.
@@ -131,7 +131,6 @@ def parse_cohort_parameters(args):
     elif args.bucket_start_date:
         mode = "bucket"
         date = args.bucket_start_date
-    date = int(date.strftime("%s")) * 1000
 
     period = args.period
     if period == 1:

--- a/retention/cohort_analysis.py
+++ b/retention/cohort_analysis.py
@@ -368,6 +368,8 @@ def estimate_client_types(client_types: Mapping[str, int]) -> Mapping[str, int]:
     other_count = client_types.get(OTHER, 0)
     web_count = client_types.get(WEB, 0)
 
+    combined_count = client_types.get(COMBINED, 0)
+
     missing_count = client_types.get(MISSING, 0)
 
     if missing_count > 0:
@@ -384,7 +386,8 @@ def estimate_client_types(client_types: Mapping[str, int]) -> Mapping[str, int]:
                     RIOTX_ANDROID: riotx_android_count,
                     ELEMENT_ELECTRON: element_electron_count,
                     ELEMENT_IOS: element_ios_count,
-                    WEB: web_count})
+                    WEB: web_count,
+                    COMBINED: combined_count})
 
 
 def get_cohort_users_and_client_mapping(

--- a/retention/cohort_analysis.py
+++ b/retention/cohort_analysis.py
@@ -438,22 +438,6 @@ class CohortKey:
     sso_idp = attr.ib(type=str)
 
 
-@attr.s(frozen=True, slots=True)
-class ClientAgnosticCohortKey:
-    """
-    This is like CohortKey, but doesn't mention the client type.
-    The point of this is to allow tracking combined metrics (combined across
-    all clients); a single user can use multiple clients and could otherwise
-    appear in multiple cohorts, so a simple sum is not correct.
-    """
-
-    # start date for the cohort
-    cohort_start_date = attr.ib(type=str)
-
-    # the SSO identity provider
-    sso_idp = attr.ib(type=str)
-
-
 def get_cohort_clients_bucket(
     cohort_users: Collection[User],
     cohort_start_date: int,
@@ -522,69 +506,9 @@ def get_cohort_clients_bucket(
             yield cohort_key, count
 
 
-def get_cohort_combined_bucket(
-    cohort_users: Collection[User],
-    cohort_start_date: int,
-    bucket_start_date: int,
-    bucket_end_date: int,
-) -> Iterable[Tuple[ClientAgnosticCohortKey, int]]:
-    """Get the count of users who used ANY client between the 2 provided dates
-
-    Args:
-        cohort_users: The cohort of users we are interested in
-
-        cohort_start_date: the start date of the user cohort
-
-        bucket_start_date: start of the timeframe to check, inclusive, as ms since the
-            epoch.
-
-        bucket_end_date: end of the timeframe to check, exclusive, as ms since the
-            epoch.
-
-    Returns:
-        A series of (client-agnostic cohort key, count) rows
-    """
-    logging.info(f"Getting client counts for cohort of size {len(cohort_users)} active between "
-                 f"{ts_to_str(bucket_start_date)} and {ts_to_str(bucket_end_date)}")
-
-    # Get a map of the device ids that were active for each user during the usage bucket
-    bucket_user_device_map = get_bucket_devices_by_user(
-        tuple(u.user_id for u in cohort_users), bucket_start_date, bucket_end_date
-    )
-
-    # Build a list of users, to deduplicate users
-    # a set of (user_id, sso_idp) pairs
-    users: Set[Tuple[str, str]] = set()
-    for user in cohort_users:
-        if user not in bucket_user_device_map:
-            # this user was not active in this part
-            # XXX i think we want this. continue
-            pass
-
-        # the user might have registered with more than one SSO IdP; if so, we just
-        # pick the first one.
-        sso_idp: str = user.auth_providers[0] if user.auth_providers else ''
-
-        users.add((user.user_id, sso_idp))
-
-    # Now, for each SSO IdP, build a count of users (regardless of client).
-    # sso_idp -> count
-    sso_bucket = Counter()
-    for (user_id, sso_idp) in users:
-        sso_bucket[sso_idp] += 1
-    # XXX logging.info(f"bucket_client_types={sso_bucket_client_types}")
-
-    for sso_idp, count in sso_bucket.items():
-        cohort_key = ClientAgnosticCohortKey(ts_to_str(cohort_start_date), sso_idp)
-        yield cohort_key, count
-
-
 # the result type of the generate methods.
 # A set of (cohort key, bucket number, count) rows
 CohortStatsResult = Iterable[Tuple[CohortKey, int, int]]
-
-# XXX
-ClientAgnosticCohortStatsResult = Iterable[Tuple[ClientAgnosticCohortKey, int, int]]
 
 
 def generate_by_cohort(

--- a/retention/schema.sql
+++ b/retention/schema.sql
@@ -71,3 +71,16 @@ ALTER TABLE `cohorts_monthly`
    ADD COLUMN `sso_idp` varchar(16) NOT NULL DEFAULT '',
    ADD UNIQUE KEY `client_idp_date` (`client`,`sso_idp`, `date`),
    DROP KEY `client_date`;
+
+
+-- add a `cohort_size` column to each of the cohort tables, so that we can track
+-- the size of the entire cohort (and therefore give relative retention in %).
+
+ALTER TABLE `cohorts_daily`
+  ADD COLUMN `cohort_size` int(11);
+
+ALTER TABLE `cohorts_weekly`
+  ADD COLUMN `cohort_size` int(11);
+
+ALTER TABLE `cohorts_monthly`
+  ADD COLUMN `cohort_size` int(11);


### PR DESCRIPTION
This PR adds the ability to get combined cohort retention statistics across all clients (without double-counting users).

It also includes some extension of the unit test suite so that we can test this actually works!

Finally, this PR also makes the script use UTC time for consistency and records the cohort size in the database.

(Sorry for re-opening, I got into a knot with it and couldn't change the branch.)