### PR TITLE
Calculate true cohort size for client-agnostic cohorts

### DIFF
--- a/retention/cohort_analysis.py
+++ b/retention/cohort_analysis.py
@@ -516,7 +516,7 @@ def get_cohort_clients_bucket(
 # the result types of the generate methods.
 # A set of (cohort key, bucket number, count, cohort size) rows describing how many users in
 # the cohort appear in the given bucket and what the size of the cohort is
-CohortStatsResult = Iterable[Tuple[CohortKey, int, int]]
+CohortStatsResult = Iterable[Tuple[CohortKey, int, int, int]]
 
 
 def generate_by_cohort(

--- a/retention/cohort_analysis.py
+++ b/retention/cohort_analysis.py
@@ -514,9 +514,21 @@ def get_cohort_clients_bucket(
 
 
 # the result types of the generate methods.
-# A set of (cohort key, bucket number, count, cohort size) rows describing how many users in
+# A set of (cohort key, bucket number, count, cohort size?) rows describing how many users in
 # the cohort appear in the given bucket and what the size of the cohort is
-CohortStatsResult = Iterable[Tuple[CohortKey, int, int, int]]
+# Cohort size is optional as we are not able to determine the true cohort
+# size per-client (since it includes users that register but do not log in).
+CohortStatsResult = Iterable[Tuple[CohortKey, int, int, Optional[int]]]
+
+
+def identity_provider_to_cohort_size(cohort_users: Collection[User]) -> Counter[str]:
+    result = Counter()
+    for user in cohort_users:
+        # the user might have registered with more than one SSO IdP; if so, we just
+        # pick the first one.
+        sso_idp = user.auth_providers[0] if user.auth_providers else ''
+        result[sso_idp] += 1
+    return result
 
 
 def generate_by_cohort(
@@ -547,6 +559,7 @@ def generate_by_cohort(
 
     cohort_users, users_and_devices_to_client = get_cohort_users_and_client_mapping(cohort_start_date,
                                                                                     cohort_end_date)
+    idp_to_cohort_size = identity_provider_to_cohort_size(cohort_users)
 
     for bucket in range(buckets):
         bucket_num = bucket + 1
@@ -562,7 +575,12 @@ def generate_by_cohort(
         )
 
         for cohort_key, count in client_types:
-            yield cohort_key, bucket_num, count, len(cohort_users)
+            if cohort_key.client_type == COMBINED:
+                cohort_size = idp_to_cohort_size[cohort_key.sso_idp]
+            else:
+                cohort_size = None
+
+            yield cohort_key, bucket_num, count, cohort_size
 
 
 def generate_by_bucket(
@@ -594,6 +612,8 @@ def generate_by_bucket(
         cohort_users, users_and_devices_to_client = get_cohort_users_and_client_mapping(cohort_start_date,
                                                                                         cohort_end_date)
 
+        idp_to_cohort_size = identity_provider_to_cohort_size(cohort_users)
+
         bucket_num = bucket + 1
         client_types = get_cohort_clients_bucket(
             cohort_users,
@@ -603,7 +623,12 @@ def generate_by_bucket(
             bucket_end_date,
         )
         for cohort_key, count in client_types:
-            yield cohort_key, bucket_num, count, len(cohort_users)
+            if cohort_key.client_type == COMBINED:
+                cohort_size = idp_to_cohort_size[cohort_key.sso_idp]
+            else:
+                cohort_size = None
+
+            yield cohort_key, bucket_num, count, cohort_size
 
 
 def write_to_mysql(table: str, buckets_stats: CohortStatsResult, dry_run: bool):

--- a/retention/test/test_cohort_analysis.py
+++ b/retention/test/test_cohort_analysis.py
@@ -1,5 +1,4 @@
 import unittest
-from pprint import pprint
 
 import retention.cohort_analysis as cohort_analysis
 from retention.cohort_analysis import CohortKey
@@ -271,26 +270,24 @@ class TestCohortAnalysis(unittest.TestCase):
             period=ONE_DAY,
         ))
 
-        pprint(results)
-
         self.assertEqual(results, [
-            (CohortKey(cohort_start_date='2018-10-05', client_type='android', sso_idp=''), 1, 2, 3),
-            (CohortKey(cohort_start_date='2018-10-05', client_type='android-riotx', sso_idp=''), 1, 0, 3),
-            (CohortKey(cohort_start_date='2018-10-05', client_type='electron', sso_idp=''), 1, 0, 3),
-            (CohortKey(cohort_start_date='2018-10-05', client_type='ios', sso_idp=''), 1, 1, 3),
-            (CohortKey(cohort_start_date='2018-10-05', client_type='web', sso_idp=''), 1, 1, 3),
+            (CohortKey(cohort_start_date='2018-10-05', client_type='android', sso_idp=''), 1, 2, None),
+            (CohortKey(cohort_start_date='2018-10-05', client_type='android-riotx', sso_idp=''), 1, 0, None),
+            (CohortKey(cohort_start_date='2018-10-05', client_type='electron', sso_idp=''), 1, 0, None),
+            (CohortKey(cohort_start_date='2018-10-05', client_type='ios', sso_idp=''), 1, 1, None),
+            (CohortKey(cohort_start_date='2018-10-05', client_type='web', sso_idp=''), 1, 1, None),
             (CohortKey(cohort_start_date='2018-10-05', client_type='combined', sso_idp=''), 1, 3, 3),
-            (CohortKey(cohort_start_date='2018-10-05', client_type='android', sso_idp=''), 2, 2, 3),
-            (CohortKey(cohort_start_date='2018-10-05', client_type='android-riotx', sso_idp=''), 2, 0, 3),
-            (CohortKey(cohort_start_date='2018-10-05', client_type='electron', sso_idp=''), 2, 0, 3),
-            (CohortKey(cohort_start_date='2018-10-05', client_type='ios', sso_idp=''), 2, 1, 3),
-            (CohortKey(cohort_start_date='2018-10-05', client_type='web', sso_idp=''), 2, 1, 3),
+            (CohortKey(cohort_start_date='2018-10-05', client_type='android', sso_idp=''), 2, 2, None),
+            (CohortKey(cohort_start_date='2018-10-05', client_type='android-riotx', sso_idp=''), 2, 0, None),
+            (CohortKey(cohort_start_date='2018-10-05', client_type='electron', sso_idp=''), 2, 0, None),
+            (CohortKey(cohort_start_date='2018-10-05', client_type='ios', sso_idp=''), 2, 1, None),
+            (CohortKey(cohort_start_date='2018-10-05', client_type='web', sso_idp=''), 2, 1, None),
             (CohortKey(cohort_start_date='2018-10-05', client_type='combined', sso_idp=''), 2, 3, 3),
-            (CohortKey(cohort_start_date='2018-10-05', client_type='android', sso_idp=''), 3, 0, 3),
-            (CohortKey(cohort_start_date='2018-10-05', client_type='android-riotx', sso_idp=''), 3, 0, 3),
-            (CohortKey(cohort_start_date='2018-10-05', client_type='electron', sso_idp=''), 3, 0, 3),
-            (CohortKey(cohort_start_date='2018-10-05', client_type='ios', sso_idp=''), 3, 0, 3),
-            (CohortKey(cohort_start_date='2018-10-05', client_type='web', sso_idp=''), 3, 1, 3),
+            (CohortKey(cohort_start_date='2018-10-05', client_type='android', sso_idp=''), 3, 0, None),
+            (CohortKey(cohort_start_date='2018-10-05', client_type='android-riotx', sso_idp=''), 3, 0, None),
+            (CohortKey(cohort_start_date='2018-10-05', client_type='electron', sso_idp=''), 3, 0, None),
+            (CohortKey(cohort_start_date='2018-10-05', client_type='ios', sso_idp=''), 3, 0, None),
+            (CohortKey(cohort_start_date='2018-10-05', client_type='web', sso_idp=''), 3, 1, None),
             (CohortKey(cohort_start_date='2018-10-05', client_type='combined', sso_idp=''), 3, 1, 3)
         ])
 
@@ -319,7 +316,6 @@ class TestCohortAnalysis(unittest.TestCase):
         add_user_daily_visit_entry("user2", "U2D2", "Element (Android; ...)", cohort_analysis.str_to_ts("2018-10-06"))
         add_user_daily_visit_entry("user3", "U3D1", "Element (Android; ...)", cohort_analysis.str_to_ts("2018-10-06"))
         add_user_daily_visit_entry("user3", "U3D1", "Element (Android; ...)", cohort_analysis.str_to_ts("2018-10-07"))
-        add_user_daily_visit_entry("user4", "U4D1", "Element (Android; ...)", cohort_analysis.str_to_ts("2018-10-05"))
         add_user_daily_visit_entry("user4", "U4D1", "Element (Android; ...)", cohort_analysis.str_to_ts("2018-10-06"))
         add_user_daily_visit_entry("user4", "U4D1", "Element (Android; ...)", cohort_analysis.str_to_ts("2018-10-07"))
         add_user_daily_visit_entry("user5", "U5D1", "Element (Android; ...)", cohort_analysis.str_to_ts("2018-10-06"))
@@ -331,17 +327,17 @@ class TestCohortAnalysis(unittest.TestCase):
         ))
 
         self.assertEqual(results, [
-            (CohortKey(cohort_start_date='2018-10-06', client_type='android', sso_idp=''), 1, 2, 2),
-            (CohortKey(cohort_start_date='2018-10-06', client_type='android-riotx', sso_idp=''), 1, 0, 2),
-            (CohortKey(cohort_start_date='2018-10-06', client_type='electron', sso_idp=''), 1, 0, 2),
-            (CohortKey(cohort_start_date='2018-10-06', client_type='ios', sso_idp=''), 1, 0, 2),
-            (CohortKey(cohort_start_date='2018-10-06', client_type='web', sso_idp=''), 1, 0, 2),
+            (CohortKey(cohort_start_date='2018-10-06', client_type='android', sso_idp=''), 1, 2, None),
+            (CohortKey(cohort_start_date='2018-10-06', client_type='android-riotx', sso_idp=''), 1, 0, None),
+            (CohortKey(cohort_start_date='2018-10-06', client_type='electron', sso_idp=''), 1, 0, None),
+            (CohortKey(cohort_start_date='2018-10-06', client_type='ios', sso_idp=''), 1, 0, None),
+            (CohortKey(cohort_start_date='2018-10-06', client_type='web', sso_idp=''), 1, 0, None),
             (CohortKey(cohort_start_date='2018-10-06', client_type='combined', sso_idp=''), 1, 2, 2),
-            (CohortKey(cohort_start_date='2018-10-05', client_type='android', sso_idp=''), 2, 2, 3),
-            (CohortKey(cohort_start_date='2018-10-05', client_type='android-riotx', sso_idp=''), 2, 0, 3),
-            (CohortKey(cohort_start_date='2018-10-05', client_type='electron', sso_idp=''), 2, 0, 3),
-            (CohortKey(cohort_start_date='2018-10-05', client_type='ios', sso_idp=''), 2, 1, 3),
-            (CohortKey(cohort_start_date='2018-10-05', client_type='web', sso_idp=''), 2, 1, 3),
+            (CohortKey(cohort_start_date='2018-10-05', client_type='android', sso_idp=''), 2, 2, None),
+            (CohortKey(cohort_start_date='2018-10-05', client_type='android-riotx', sso_idp=''), 2, 0, None),
+            (CohortKey(cohort_start_date='2018-10-05', client_type='electron', sso_idp=''), 2, 0, None),
+            (CohortKey(cohort_start_date='2018-10-05', client_type='ios', sso_idp=''), 2, 1, None),
+            (CohortKey(cohort_start_date='2018-10-05', client_type='web', sso_idp=''), 2, 1, None),
             (CohortKey(cohort_start_date='2018-10-05', client_type='combined', sso_idp=''), 2, 3, 3)
         ])
 

--- a/retention/test/test_cohort_analysis.py
+++ b/retention/test/test_cohort_analysis.py
@@ -1,12 +1,15 @@
 import unittest
+from pprint import pprint
+
 import retention.cohort_analysis as cohort_analysis
 from retention.cohort_analysis import CohortKey
 
 CONFIG = cohort_analysis.Config()
 
+ONE_DAY = 86400_000
+
 
 def configure_test_db():
-
     sql_create_users = """
         DROP TABLE IF EXISTS users;
         CREATE TABLE users(
@@ -59,7 +62,6 @@ def configure_test_db():
     """
 
     with CONFIG.get_conn() as conn:
-
         # create tables
         if conn is not None:
             # It is necessary to overide the readonly flag for tests, in order
@@ -157,6 +159,8 @@ def add_user_daily_visit_entry(user_id: str, device_id: str, user_agent: str, ti
 
 
 class TestCohortAnalysis(unittest.TestCase):
+    maxDiff = None
+
     def setUp(self):
         configure_test_db()
 
@@ -235,6 +239,110 @@ class TestCohortAnalysis(unittest.TestCase):
             (CohortKey("2018-10-01", "ios", ""), 1),
             (CohortKey("2018-10-01", "web", ""), 1),
             (CohortKey("2018-10-01", "combined", ""), 2)
+        ])
+
+    def test_generate_by_cohort(self):
+        """
+        Test the generate_by_cohort function.
+        THIS TEST CONTAINS A BUG WHICH MATCHES THE CURRENT IMPLEMENTATION.
+        """
+
+        cohort_start_date = cohort_analysis.str_to_ts("2018-10-05")
+
+        # create some users
+        add_new_user_entry("user1", cohort_analysis.str_to_ts("2018-10-05"))
+        add_new_user_entry("user2", cohort_analysis.str_to_ts("2018-10-05"))
+        add_new_user_entry("user3", cohort_analysis.str_to_ts("2018-10-05"))
+
+        # add some visits for the users
+        add_user_daily_visit_entry("user1", "U1D1", "Mozilla/5.0", cohort_analysis.str_to_ts("2018-10-05"))
+        add_user_daily_visit_entry("user1", "U1D1", "Mozilla/5.0", cohort_analysis.str_to_ts("2018-10-06"))
+        add_user_daily_visit_entry("user1", "U1D1", "Mozilla/5.0", cohort_analysis.str_to_ts("2018-10-07"))
+        add_user_daily_visit_entry("user2", "U2D1", "Riot (iOS; ...)", cohort_analysis.str_to_ts("2018-10-05"))
+        add_user_daily_visit_entry("user2", "U2D1", "Riot (iOS; ...)", cohort_analysis.str_to_ts("2018-10-06"))
+        add_user_daily_visit_entry("user2", "U2D2", "Element (Android; ...)", cohort_analysis.str_to_ts("2018-10-05"))
+        add_user_daily_visit_entry("user2", "U2D2", "Element (Android; ...)", cohort_analysis.str_to_ts("2018-10-06"))
+        add_user_daily_visit_entry("user3", "U3D1", "Element (Android; ...)", cohort_analysis.str_to_ts("2018-10-05"))
+        add_user_daily_visit_entry("user3", "U3D1", "Element (Android; ...)", cohort_analysis.str_to_ts("2018-10-06"))
+
+        results = list(cohort_analysis.generate_by_cohort(
+            cohort_start_date,
+            buckets=7,
+            period=ONE_DAY,
+        ))
+
+        pprint(results)
+
+        self.assertEqual(results, [
+            (CohortKey(cohort_start_date='2018-10-05', client_type='android', sso_idp=''), 1, 2, 3),
+            (CohortKey(cohort_start_date='2018-10-05', client_type='android-riotx', sso_idp=''), 1, 0, 3),
+            (CohortKey(cohort_start_date='2018-10-05', client_type='electron', sso_idp=''), 1, 0, 3),
+            (CohortKey(cohort_start_date='2018-10-05', client_type='ios', sso_idp=''), 1, 1, 3),
+            (CohortKey(cohort_start_date='2018-10-05', client_type='web', sso_idp=''), 1, 1, 3),
+            (CohortKey(cohort_start_date='2018-10-05', client_type='combined', sso_idp=''), 1, 3, 3),
+            (CohortKey(cohort_start_date='2018-10-05', client_type='android', sso_idp=''), 2, 2, 3),
+            (CohortKey(cohort_start_date='2018-10-05', client_type='android-riotx', sso_idp=''), 2, 0, 3),
+            (CohortKey(cohort_start_date='2018-10-05', client_type='electron', sso_idp=''), 2, 0, 3),
+            (CohortKey(cohort_start_date='2018-10-05', client_type='ios', sso_idp=''), 2, 1, 3),
+            (CohortKey(cohort_start_date='2018-10-05', client_type='web', sso_idp=''), 2, 1, 3),
+            (CohortKey(cohort_start_date='2018-10-05', client_type='combined', sso_idp=''), 2, 3, 3),
+            (CohortKey(cohort_start_date='2018-10-05', client_type='android', sso_idp=''), 3, 0, 3),
+            (CohortKey(cohort_start_date='2018-10-05', client_type='android-riotx', sso_idp=''), 3, 0, 3),
+            (CohortKey(cohort_start_date='2018-10-05', client_type='electron', sso_idp=''), 3, 0, 3),
+            (CohortKey(cohort_start_date='2018-10-05', client_type='ios', sso_idp=''), 3, 0, 3),
+            (CohortKey(cohort_start_date='2018-10-05', client_type='web', sso_idp=''), 3, 1, 3),
+            (CohortKey(cohort_start_date='2018-10-05', client_type='combined', sso_idp=''), 3, 1, 3)
+        ])
+
+    def test_generate_by_bucket(self):
+        """
+        Test the generate_by_bucket function.
+        THIS TEST CONTAINS A BUG WHICH MATCHES THE CURRENT IMPLEMENTATION.
+        """
+
+        bucket_start_date = cohort_analysis.str_to_ts("2018-10-06")
+
+        # create some users
+        add_new_user_entry("user1", cohort_analysis.str_to_ts("2018-10-05"))
+        add_new_user_entry("user2", cohort_analysis.str_to_ts("2018-10-05"))
+        add_new_user_entry("user3", cohort_analysis.str_to_ts("2018-10-05"))
+        add_new_user_entry("user4", cohort_analysis.str_to_ts("2018-10-06"))
+        add_new_user_entry("user5", cohort_analysis.str_to_ts("2018-10-06"))
+
+        # add some visits for the users
+        add_user_daily_visit_entry("user1", "U1D1", "Mozilla/5.0", cohort_analysis.str_to_ts("2018-10-05"))
+        add_user_daily_visit_entry("user1", "U1D1", "Mozilla/5.0", cohort_analysis.str_to_ts("2018-10-06"))
+        add_user_daily_visit_entry("user1", "U1D1", "Mozilla/5.0", cohort_analysis.str_to_ts("2018-10-07"))
+        add_user_daily_visit_entry("user2", "U2D1", "Riot (iOS; ...)", cohort_analysis.str_to_ts("2018-10-05"))
+        add_user_daily_visit_entry("user2", "U2D1", "Riot (iOS; ...)", cohort_analysis.str_to_ts("2018-10-06"))
+        add_user_daily_visit_entry("user2", "U2D2", "Element (Android; ...)", cohort_analysis.str_to_ts("2018-10-05"))
+        add_user_daily_visit_entry("user2", "U2D2", "Element (Android; ...)", cohort_analysis.str_to_ts("2018-10-06"))
+        add_user_daily_visit_entry("user3", "U3D1", "Element (Android; ...)", cohort_analysis.str_to_ts("2018-10-06"))
+        add_user_daily_visit_entry("user3", "U3D1", "Element (Android; ...)", cohort_analysis.str_to_ts("2018-10-07"))
+        add_user_daily_visit_entry("user4", "U4D1", "Element (Android; ...)", cohort_analysis.str_to_ts("2018-10-05"))
+        add_user_daily_visit_entry("user4", "U4D1", "Element (Android; ...)", cohort_analysis.str_to_ts("2018-10-06"))
+        add_user_daily_visit_entry("user4", "U4D1", "Element (Android; ...)", cohort_analysis.str_to_ts("2018-10-07"))
+        add_user_daily_visit_entry("user5", "U5D1", "Element (Android; ...)", cohort_analysis.str_to_ts("2018-10-06"))
+
+        results = list(cohort_analysis.generate_by_bucket(
+            bucket_start_date,
+            buckets=7,
+            period=ONE_DAY,
+        ))
+
+        self.assertEqual(results, [
+            (CohortKey(cohort_start_date='2018-10-06', client_type='android', sso_idp=''), 1, 2, 2),
+            (CohortKey(cohort_start_date='2018-10-06', client_type='android-riotx', sso_idp=''), 1, 0, 2),
+            (CohortKey(cohort_start_date='2018-10-06', client_type='electron', sso_idp=''), 1, 0, 2),
+            (CohortKey(cohort_start_date='2018-10-06', client_type='ios', sso_idp=''), 1, 0, 2),
+            (CohortKey(cohort_start_date='2018-10-06', client_type='web', sso_idp=''), 1, 0, 2),
+            (CohortKey(cohort_start_date='2018-10-06', client_type='combined', sso_idp=''), 1, 2, 2),
+            (CohortKey(cohort_start_date='2018-10-05', client_type='android', sso_idp=''), 2, 2, 3),
+            (CohortKey(cohort_start_date='2018-10-05', client_type='android-riotx', sso_idp=''), 2, 0, 3),
+            (CohortKey(cohort_start_date='2018-10-05', client_type='electron', sso_idp=''), 2, 0, 3),
+            (CohortKey(cohort_start_date='2018-10-05', client_type='ios', sso_idp=''), 2, 1, 3),
+            (CohortKey(cohort_start_date='2018-10-05', client_type='web', sso_idp=''), 2, 1, 3),
+            (CohortKey(cohort_start_date='2018-10-05', client_type='combined', sso_idp=''), 2, 3, 3)
         ])
 
 


### PR DESCRIPTION
We can't calculate these per-client, so NULL is used in the client-specific rows.