### PR TITLE
Bump up Python to 3.9 and make it the same in unit tests and production

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: actions/setup-python@v2
         with:
-          python-version: "3.x"
+          python-version: "3.7"
 
       - name: Install requirements
         run: pip install -r retention/requirements.txt

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: actions/setup-python@v2
         with:
-          python-version: "3.7"
+          python-version: "3.9"
 
       - name: Install requirements
         run: pip install -r retention/requirements.txt

--- a/retention/Dockerfile
+++ b/retention/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7
+FROM python:3.9
 
 WORKDIR /app
 


### PR DESCRIPTION
Sad mistake where production was running Python 3.7 which choked on some of the type annotations (*serves you right for trying to write nice code!*), but unit tests were running '3.x' which presumably means 3.9 which is happy with those. (I also ran it all locally before 'release' using 3.9 and had no issue.)